### PR TITLE
add --save command to npm install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use one API, thanks to Segment.io's [analytics.js](https://segment.com/docs/libr
 
 ## Installation
 
-`> npm install @okgrow/auto-analytics`
+`> npm install @okgrow/auto-analytics --save`
 
 ## Currently Supported Analytic Services
 * Amplitude


### PR DESCRIPTION
Noticed --save command was missing for the npm install instructions