### PR TITLE
V1.0.3

### DIFF
--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -12,6 +12,6 @@
     "react-dom": "^15.4.2",
     "react-komposer": "^2.0.0",
     "react-router": "^3.0.2",
-    "@okgrow/auto-analytics": "^1.0.2"
+    "@okgrow/auto-analytics": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okgrow/auto-analytics",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Complete automatic pageview tracking with Google Analytics, Mixpanel, KISSmetrics (and more) integration for JavaScript applications.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Changes Made:**
- Referrer will now correctly reference the original referrer when browsers back/fwd buttons are used.
- Title & Name will will not be from the previous route when packages like react-helmet, or react-document-title, etc... are used to set the `document.title`.
- Bump version numbers.

Note: Fixes are back ported from the work completed on the [v2.0.0 release](https://github.com/okgrow/auto-analytics/pull/9).

Tested locally against the example app.