### PR TITLE
V1.0.6

### DIFF
--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -12,6 +12,6 @@
     "react-dom": "^15.4.2",
     "react-komposer": "^2.0.0",
     "react-router": "^3.0.2",
-    "@okgrow/auto-analytics": "^1.0.5"
+    "@okgrow/auto-analytics": "^1.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okgrow/auto-analytics",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Complete automatic pageview tracking with Google Analytics, Mixpanel, KISSmetrics (and more) integration for JavaScript applications.",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ const logPageLoad = ({ referrer, delay }) => {
 
 // A simple wrapper to be explicit about doing the first page load...
 const logFirstPageLoad = () => {
-  // Ensure we copy over any existing state when we call replaceState
-  const currentState = window.history.state;
+  // Ensure we copy over existing state (when it's an object/array) when we use replaceState 
+  const currentState = typeof window.history.state === 'object' ? window.history.state : null;
   // Store the referrer incase a user uses their browsers back button.
   // NOTE: We only wish to update the state, so we don't pass a 3rd param the URL.
   window.history.replaceState({ ...currentState, referrer: document.referrer }, '');

--- a/src/index.js
+++ b/src/index.js
@@ -30,9 +30,11 @@ const logPageLoad = ({ referrer, delay }) => {
 
 // A simple wrapper to be explicit about doing the first page load...
 const logFirstPageLoad = () => {
+  // Ensure we copy over any existing state when we call replaceState
+  const currentState = window.history.state;
   // Store the referrer incase a user uses their browsers back button.
   // NOTE: We only wish to update the state, so we don't pass a 3rd param the URL.
-  window.history.replaceState({ referrer: document.referrer }, '');
+  window.history.replaceState({ ...currentState, referrer: document.referrer }, '');
   logPageLoad({ referrer: document.referrer });
 };
 
@@ -72,7 +74,7 @@ const configurePageLoadTracking = () => {
     // If the history is manipulated, by setting a hash for example,
     // the state property may be absent when a popstate is triggered
     const { referrer = '' } = window.history.state || {};
-    
+
     // NOTE: A delay is added as document.title wont be updated yet if packages
     // like react-helmet or react-document-title, etc... are used.
     logPageLoad({ referrer: referrer || '', delay: 50 });


### PR DESCRIPTION
**Changes Made:**
- Fix for reported [FlowRouter + Meteor 1.6 bug](https://github.com/meteor/meteor/issues/9419), reported to us in our Meteor Analytics pkg [here](https://github.com/okgrow/analytics/issues/203).
- Bump npm version to 1.0.6 

**NOTE:**
- The fix implemented will ensure that any existing state that may exist on first page load is copied across when we use the `replaceState` in our `logFirstPageLoad`. 
- We should maybe think about using a different key in the state object. Currently we use`referrer`, but it is possible this may cause some confusion to developers or potentially be overwritten. Maybe something like `okg_auto_analytics_referrer` would be more unique and distinguishable.

